### PR TITLE
redirect to queerinai.org from the index page

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 
 <head>
     <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=http://queerinai.org">
     <meta name="author" content="William Agnew">
     <meta name="description" content="Queer In AI">
     <meta name="keywords" content="LGBTQ, Queer, Artificial Intelligence, Machine Learning, Workshop">
@@ -31,7 +32,7 @@
     <![endif]-->
 </head>
 
-<body data-spy="scroll" data-target="#primary-menu">
+<body data-spy="scroll" data-target="#primary-menu" onload="window.location = 'http://queerinai.org';">
 
     <!--Mainmenu-area-->
     <div class="mainmenu-area" data-spy="affix" data-offset-top="100">


### PR DESCRIPTION
The [ICML site](https://icml.cc/public/DiversityInclusion) and probably some other places still link to this older site, and there's no indication here that there's a different website. This makes the homepage of this site (`https://queerai.github.io/QueerInAI/`) just automatically redirect to `http://queerinai.org` (which then redirects along to the Google Sites page); there isn't a way to do proper server-side redirects on github pages, but this should be smooth enough.

Probably better to add a "go to our new site" notice to the other pages as well/instead, but I didn't do that.